### PR TITLE
Prevent unneccessary queries when mustmakeenabled is false

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -697,6 +697,12 @@ class grade_report_forecast extends grade_report {
      * @return bool
      */
     private function shouldShowMustMake() {
+        global $CFG;
+
+        if (!$CFG->grade_report_forecast_mustmakeenabled) {
+            return false;
+        }
+
         if ( ! (array_key_exists('totalUngradedItemCount', $this->inputData) and array_key_exists('inputGradeItemCount', $this->inputData))) {
             return false;
         }


### PR DESCRIPTION
In our use of this plugin, we keep the mustmake feature disabled. When students were heavily using the report, we noticed a large volume of queries being executed. This was due to the plugin running the grade_report_forecast::claculateMustMake() method. The output of this method would be ignored since the grade_report_forecast_mustmakeenabled is set to false based on our configuration.

To reduce load on our database, I have added a small condition that will return false on grade_report_forecast::claculateMustMake() if grade_report_forecast_mustmakeenabled is set to false. This skips the executions of the queries with results that weren't required.

Thanks for authoring this plugin! Many of our students are using it regularly.